### PR TITLE
Post interaction hover effects and other UI fixes

### DIFF
--- a/src/components/CreatePost/CreatePost.tsx
+++ b/src/components/CreatePost/CreatePost.tsx
@@ -9,7 +9,7 @@ import { ModalContext } from '../../contexts/ModalContext'
 
 interface ICreatePostProps {
   isReply?: Boolean
-  replyModalPost: IUserPost
+  replyModalPost?: IUserPost
 }
 
 const CreatePost: FunctionComponent<ICreatePostProps> = ({ isReply, replyModalPost }) => {
@@ -52,7 +52,11 @@ const CreatePost: FunctionComponent<ICreatePostProps> = ({ isReply, replyModalPo
   }
 
   return (
-    <div className={`pb-3 mt-5 mx-auto px-3 ${!replyModalPost && 'border-b'} border-slate-700`}>
+    <div
+      className={`pb-3 pt-5 mx-auto px-3 ${
+        !replyModalPost && 'border-slate-700 border-l border-r border-b'
+      } `}
+    >
       <form action='submit' onSubmit={onSubmitHandler}>
         <textarea
           name='postContent'

--- a/src/components/Feed/FeedContainer.tsx
+++ b/src/components/Feed/FeedContainer.tsx
@@ -1,9 +1,7 @@
 function FeedContainer({ children }) {
   return (
-    <div className='flex w-full'>
-      <div className='lg:w-3/5 max-w-3xl mx-auto border-l border-r border-slate-700'>
-        {children}
-      </div>
+    <div className='flex w-full min-h-screen'>
+      <div className='lg:w-3/5 max-w-3xl mx-auto border-slate-700 w-full'>{children}</div>
     </div>
   )
 }

--- a/src/components/Forms/FormInput.tsx
+++ b/src/components/Forms/FormInput.tsx
@@ -4,7 +4,7 @@ const FormInput = ({ value, name, onChange, label }) => {
       <label className='absolute text-gray-400 ml-2'>{label}</label>
       <input
         type='text'
-        className='w-11/12 h-14 bg-slate-900 border border-white rounded-md focus:border-cyan-300 focus:outline-none focus:ring-0 pl-2 pt-5'
+        className='w-11/12 h-14 bg-slate-900 border border-slate-700 rounded-md focus:border-cyan-300 focus:outline-none focus:ring-0 pl-2 pt-5'
         name={name}
         value={value}
         onChange={onChange}

--- a/src/components/Modal/CreateReplyModal.tsx
+++ b/src/components/Modal/CreateReplyModal.tsx
@@ -35,14 +35,16 @@ const CreateReplyModal: FunctionComponent<ICreateReplyModalProps> = ({ post }) =
           <ProfilePicBubble addedClasses='mx-5 h-8 w-8 mt-5' />
           <PostInfo post={post} />
         </PostInfoContainer>
-        <PostContent content={post.content} addedClasses='ml-8 mt-3 border-l pl-8' />
+        <div className='border-l border-slate-500 ml-9 -mt-3'>
+          <PostContent content={post.content} addedClasses='ml-0 mt-3 pl-8' />
+          <div className='ml-8 text-gray-500'>
+            <span>Replying to: </span>
+            <Link to={`/${post.username}`}>
+              <span className='text-cyan-700'>@{post.username}</span>
+            </Link>
+          </div>
+        </div>
       </PostContainer>
-      <div className='ml-16 text-gray-500'>
-        <span>Replying to: </span>
-        <Link to={`/${post.username}`}>
-          <span className='text-cyan-700'>@{post.username}</span>
-        </Link>
-      </div>
       <CreatePost isReply={true} replyModalPost={post} />
     </div>
   )

--- a/src/components/Modal/CreateReplyModal.tsx
+++ b/src/components/Modal/CreateReplyModal.tsx
@@ -1,15 +1,17 @@
 import { FunctionComponent, MouseEventHandler, useContext } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+
 import { IUserPost } from '../../contexts/UserPosts'
 
 import { FeedContext } from '../../contexts/FeedContext'
 import { ModalContext } from '../../contexts/ModalContext'
+import { UserContext } from '../../contexts/User'
 
 import PostContainer from '../Posts/PostContainer'
 import PostInfoContainer from '../Posts/PostInfoContainer'
 import ProfilePicBubble from '../Profile/ProfilePicBubble'
 import PostInfo from '../Posts/PostInfo'
 import PostContent from '../Posts/PostContent'
-import { Link } from 'react-router-dom'
 import CreatePost from '../CreatePost/CreatePost'
 
 interface ICreateReplyModalProps {
@@ -19,6 +21,7 @@ interface ICreateReplyModalProps {
 const CreateReplyModal: FunctionComponent<ICreateReplyModalProps> = ({ post }) => {
   const { isLoading } = useContext(FeedContext)
   const { setModalIsOpen } = useContext(ModalContext)
+  const { currentAuthUser } = useContext(UserContext)
 
   const modalCloseHandler: MouseEventHandler = (e) => {
     e.preventDefault()
@@ -30,22 +33,26 @@ const CreateReplyModal: FunctionComponent<ICreateReplyModalProps> = ({ post }) =
       <span onClick={modalCloseHandler} className='ml-6 text-xl hover:cursor-pointer'>
         X
       </span>
-      <PostContainer isLoading={isLoading}>
-        <PostInfoContainer>
-          <ProfilePicBubble addedClasses='mx-5 h-8 w-8 mt-5' />
-          <PostInfo post={post} />
-        </PostInfoContainer>
-        <div className='border-l border-slate-500 ml-9 -mt-3'>
-          <PostContent content={post.content} addedClasses='ml-0 mt-3 pl-8' />
-          <div className='ml-8 text-gray-500'>
-            <span>Replying to: </span>
-            <Link to={`/${post.username}`}>
-              <span className='text-cyan-700'>@{post.username}</span>
-            </Link>
-          </div>
-        </div>
-      </PostContainer>
-      <CreatePost isReply={true} replyModalPost={post} />
+      {currentAuthUser && (
+        <>
+          <PostContainer isLoading={isLoading}>
+            <PostInfoContainer>
+              <ProfilePicBubble addedClasses='mx-5 h-8 w-8 mt-5' />
+              <PostInfo post={post} />
+            </PostInfoContainer>
+            <div className='border-l border-slate-500 ml-9 -mt-3'>
+              <PostContent content={post.content} addedClasses='mt-3 ml-8' />
+              <div className='ml-8 text-gray-500'>
+                <span>Replying to: </span>
+                <Link to={`/${post.username}`}>
+                  <span className='text-cyan-700'>@{post.username}</span>
+                </Link>
+              </div>
+            </div>
+          </PostContainer>
+          <CreatePost isReply={true} replyModalPost={post} />
+        </>
+      )}
     </div>
   )
 }

--- a/src/components/Modal/LoginWarningModal.tsx
+++ b/src/components/Modal/LoginWarningModal.tsx
@@ -1,0 +1,89 @@
+import { useContext } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { MdChat, MdFavorite, MdRepeat, MdClose } from 'react-icons/md'
+
+import Button from '../Button'
+
+import { ModalContext } from '../../contexts/ModalContext'
+
+const LoginWarningModal = () => {
+  const { setModalIsOpen, loginWarningType } = useContext(ModalContext)
+
+  const navigate = useNavigate()
+
+  return (
+    <>
+      <div
+        className=' ml-3 w-10 mt-3 rounded-full hover:cursor-pointer hover:bg-slate-800'
+        onClick={() => setModalIsOpen(false)}
+      >
+        <div className='p-1'>
+          <MdClose className='text-3xl w-full h-full' />
+        </div>
+      </div>
+      <div className='w-3/4 mx-auto'>
+        <div className='mt-8 mb-10 text-center'>
+          {loginWarningType === 'comment' && (
+            <div className=''>
+              <MdChat className='w-full text-5xl mx-auto mb-4 text-cyan-400' />
+              <div className='text-left mx-auto mt-10'>
+                <span className='text-2xl font-bold'>Comment to join the conversation.</span>
+              </div>
+              <div className='text-left mx-auto mt-3'>
+                <span className='text-slate-500'>
+                  Join Minnesota United Fan Club to reply to this post.
+                </span>
+              </div>
+            </div>
+          )}
+          {loginWarningType === 'like' && (
+            <div className=''>
+              <MdFavorite className='w-full text-5xl mx-auto mb-4 text-red-400' />
+              <div className='text-left mx-auto mt-10'>
+                <span className='text-2xl font-bold'>Show some love.</span>
+              </div>
+              <div className='text-left mx-auto mt-3'>
+                <span className='text-slate-500'>Join Minnesota United Fan Club to like post.</span>
+              </div>
+            </div>
+          )}
+          {loginWarningType === 'repost' && (
+            <div className=''>
+              <MdRepeat className='w-full text-5xl mx-auto mb-4 text-green-400' />
+              <div className='text-left mx-auto mt-10'>
+                <span className='text-2xl font-bold'>Repost to share with others.</span>
+              </div>
+              <div className='text-left mx-auto mt-3'>
+                <span className='text-slate-500'>
+                  Join Minnesota United Fan Club to reply to this post.
+                </span>
+              </div>
+            </div>
+          )}
+          <Button
+            type='button'
+            addedClasses='text-lg py-2 px-8 mt-10 bg-slate-950 hover:bg-slate-900 text-white border border-white w-full'
+            onClick={() => {
+              navigate('/login')
+              setModalIsOpen(false)
+            }}
+          >
+            Log in
+          </Button>
+          <Button
+            type='button'
+            addedClasses='text-lg py-2 px-8 mt-3 w-full hover:bg-cyan-500'
+            onClick={() => {
+              navigate('/login')
+              setModalIsOpen(false)
+            }}
+          >
+            Sign Up
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}
+export default LoginWarningModal

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -4,9 +4,10 @@ import EditProfileForm from '../Forms/EditProfileForm'
 import { ModalContext } from '../../contexts/ModalContext'
 import CreateReplyModal from './CreateReplyModal'
 import { IUserPost, UserPostsContext } from '../../contexts/UserPosts'
+import LoginWarningModal from './LoginWarningModal'
 
 function Modal({ children }) {
-  const { modalIsOpen, modalType, replyModalPostId } = useContext(ModalContext)
+  const { modalIsOpen, modalType, replyModalPostId, setModalIsOpen } = useContext(ModalContext)
   const { userPosts } = useContext(UserPostsContext)
 
   const replyModalPost: IUserPost =
@@ -15,17 +16,18 @@ function Modal({ children }) {
   return (
     <div>
       {modalIsOpen && (
-        <div className={`mt-28 fixed mx-auto w-full z-50 h-screen `}>
-          <div className='bg-slate-950 w-3/5 lg:w-1/2 max-w-xl z-0 mx-auto rounded-xl'>
+        <div className={`flex fixed mx-auto w-full z-50 h-screen items-center`}>
+          <div className='bg-slate-950 w-3/5 lg:w-1/2 max-w-xl z-10 mx-auto rounded-xl'>
             {modalType == 'editProfile' && <EditProfileForm />}
             {modalType == 'createPostReply' && (
               <div className='py-10'>{userPosts && <CreateReplyModal post={replyModalPost} />}</div>
             )}
+            {modalType == 'loginWarning' && <LoginWarningModal />}
           </div>
         </div>
       )}
 
-      <div className={`${modalIsOpen && 'opacity-40 bg-gray-500 '}w-full h-full -z-10`}>
+      <div className={`${modalIsOpen && 'opacity-40 bg-gray-500 '}w-full h-full z-10`}>
         {children}
       </div>
     </div>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -10,7 +10,7 @@ function NavBar() {
   const { currentAuthUser } = useContext(UserContext)
 
   return (
-    <div className='dark:bg-slate-900 sticky top-0 flex border-b border-slate-700 mx-auto pb-5'>
+    <div className='dark:bg-slate-900 sticky top-0 flex border-b border-slate-700 mx-auto pb-5 z-10'>
       <div className='w-14 mt-3 ml-5'>
         <Link to='/'>
           <img

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -45,7 +45,7 @@ function Post({ post, postPage }) {
   if (post.replyTo && !postPage && originalPost) {
     return (
       <Link to={`/${post.username}/status/${post.postId}`}>
-        <div className='border-b border-slate-700'>
+        <div className='border-b border-l border-r border-slate-700'>
           <PostContainer isLoading={isLoading}>
             <PostInfoContainer>
               <ProfilePicBubble
@@ -54,7 +54,7 @@ function Post({ post, postPage }) {
               />
               <PostInfo post={post} />
             </PostInfoContainer>
-            <PostContent content={post.content} />
+            <PostContent content={post.content} addedClasses='ml-16' />
           </PostContainer>
           <div
             onClick={navigateToPostOnClick}
@@ -69,7 +69,7 @@ function Post({ post, postPage }) {
                 />
                 <PostInfo post={originalPost} />
               </PostInfoContainer>
-              <PostContent content={originalPost.content} />
+              <PostContent content={originalPost.content} addedClasses='ml-16' />
             </PostContainer>
           </div>
           <PostInteractionBar post={post} />
@@ -80,7 +80,10 @@ function Post({ post, postPage }) {
 
   return (
     <Link to={`/${post.username}/status/${post.postId}`}>
-      <PostContainer isLoading={isLoading} addedClasses='border-b border-slate-700'>
+      <PostContainer
+        isLoading={isLoading}
+        addedClasses='border-b border-l border-r border-slate-700'
+      >
         <PostInfoContainer>
           <ProfilePicBubble
             onClick={navigateToProfileOnClick}
@@ -89,7 +92,7 @@ function Post({ post, postPage }) {
           />
           <PostInfo post={post} />
         </PostInfoContainer>
-        <PostContent content={post.content} />
+        <PostContent content={post.content} addedClasses='ml-16' />
         <PostInteractionBar post={post} />
       </PostContainer>
     </Link>

--- a/src/components/Posts/PostContent.tsx
+++ b/src/components/Posts/PostContent.tsx
@@ -6,7 +6,7 @@ interface IPostContentProps {
 }
 const PostContent: FunctionComponent<IPostContentProps> = ({ content, addedClasses }) => {
   return (
-    <div id='content-container' className={`ml-16 mb-5 ${addedClasses}`}>
+    <div id='content-container' className={`mb-5 ${addedClasses}`}>
       <span>{content}</span>
     </div>
   )

--- a/src/components/Posts/PostInteractionBar.tsx
+++ b/src/components/Posts/PostInteractionBar.tsx
@@ -8,43 +8,110 @@ import { UserContext } from '../../contexts/User'
 import { ModalContext } from '../../contexts/ModalContext'
 
 const PostInteractionBar = ({ post }) => {
-  const { currentUserDoc } = useContext(UserContext)
-  const { setModalIsOpen, setModalType, setReplyModalPostId } = useContext(ModalContext)
+  const { currentUserDoc, currentAuthUser } = useContext(UserContext)
+  const { setModalIsOpen, setModalType, setReplyModalPostId, setLoginWarningType } =
+    useContext(ModalContext)
 
   const postCommentClickHandler: MouseEventHandler = (e) => {
     e.preventDefault()
-    setModalType('createPostReply')
+    setLoginWarningType('comment')
+    setModalType(currentAuthUser ? 'createPostReply' : 'loginWarning')
     setReplyModalPostId(post.postId)
     setModalIsOpen(true)
   }
 
   const postLikeClickHandler: MouseEventHandler = (e) => {
     e.preventDefault()
+    if (!currentAuthUser) {
+      setLoginWarningType('like')
+      setModalType('loginWarning')
+      setModalIsOpen(true)
+    }
     togglePostLike(post)
+  }
+
+  const postRepostClickHandler: MouseEventHandler = (e) => {
+    e.preventDefault()
+    if (!currentAuthUser) {
+      setLoginWarningType('repost')
+      setModalType('loginWarning')
+      setModalIsOpen(true)
+    }
   }
 
   if (currentUserDoc) {
     return (
       <div className='flex w-full text-center mb-3'>
         <div className='w-1/3'>
-          <MdChat onClick={postCommentClickHandler} className='text-xl mx-auto inline' />
-          <span className='ml-2'>{post.replies.length}</span>
+          <div
+            onClick={postCommentClickHandler}
+            className='hover:bg-slate-900 hover:text-cyan-400 w-14 mx-auto p-1 rounded-full'
+          >
+            <MdChat className='text-xl inline mr-2' />
+            <span className=''>{post.replies.length}</span>
+          </div>
         </div>
         <div className='w-1/3'>
-          {currentUserDoc.likedPosts.find((likedPost) => likedPost == post.postId) ? (
-            <MdFavorite onClick={postLikeClickHandler} className='text-xl mx-auto inline' />
-          ) : (
-            <MdFavoriteBorder onClick={postLikeClickHandler} className='text-xl mx-auto inline' />
-          )}
-          <span className='ml-2'>{post.likes}</span>
+          <div
+            onClick={postLikeClickHandler}
+            className='hover:bg-slate-900 hover:text-red-400 w-14 mx-auto p-1 rounded-full'
+          >
+            {currentUserDoc.likedPosts.find((likedPost) => likedPost == post.postId) ? (
+              <div className='inline text-red-400'>
+                <MdFavorite className='text-xl mx-auto inline' />
+                <span className='ml-2'>{post.likes}</span>
+              </div>
+            ) : (
+              <div className='inline'>
+                <MdFavoriteBorder className='text-xl mx-auto inline' />
+                <span className='ml-2'>{post.likes}</span>
+              </div>
+            )}
+          </div>
         </div>
         <div className='w-1/3'>
-          <MdRepeat className='text-xl mx-auto inline' />
-          <span className='ml-2'>0</span>
+          <div
+            className='hover:bg-slate-900 hover:text-green-400 w-14 mx-auto p-1 rounded-full'
+            onClick={postRepostClickHandler}
+          >
+            <MdRepeat className='text-xl mx-auto inline' />
+            <span className='ml-2'>0</span>
+          </div>
         </div>
       </div>
     )
   }
+  return (
+    <div className='flex w-full text-center mb-3'>
+      <div className='w-1/3'>
+        <div
+          onClick={postCommentClickHandler}
+          className='hover:bg-slate-900 hover:text-cyan-400 w-14 mx-auto p-1 rounded-full'
+        >
+          <MdChat className='text-xl inline mr-2' />
+          <span className=''>{post.replies.length}</span>
+        </div>
+      </div>
+      <div className='w-1/3'>
+        <div
+          onClick={postLikeClickHandler}
+          className='hover:bg-slate-900 hover:text-red-400 w-14 mx-auto p-1 rounded-full'
+        >
+          <MdFavoriteBorder className='text-xl mx-auto inline' />
+          <span className='ml-2'>{post.likes}</span>
+        </div>
+      </div>
+      <div className='w-1/3'>
+        <div
+          className='hover:bg-slate-900 hover:text-green-400 w-14 mx-auto p-1 rounded-full'
+          onClick={postRepostClickHandler}
+        >
+          <MdRepeat className='text-xl mx-auto inline' />
+          <span className='ml-2'>0</span>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default PostInteractionBar

--- a/src/components/Posts/PostPage.tsx
+++ b/src/components/Posts/PostPage.tsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { MdArrowBack } from 'react-icons/md'
 
 import { UserPostsContext } from '../../contexts/UserPosts'
+import { UserContext } from '../../contexts/User'
 
 import Post from './Post'
 import LoadingSpinner from '../LoadingSpinner'
@@ -15,6 +16,7 @@ const PostPage = () => {
   const [pagePost, setPagePost] = useState(null)
 
   const { userPosts } = useContext(UserPostsContext)
+  const { currentAuthUser } = useContext(UserContext)
 
   const { postId } = useParams()
   const navigate = useNavigate()
@@ -39,12 +41,14 @@ const PostPage = () => {
     <FeedContainer>
       {pagePost ? (
         <Fragment>
-          <div className='text-2xl mt-3'>
+          <div className='text-2xl py-3 border-l border-r  border-slate-700'>
             <MdArrowBack onClick={goBack} className='inline mx-5 -mt-1 hover:cursor-pointer' />
-            <span>Post</span>
+            <span>
+              <b>Post</b>
+            </span>
           </div>
           <Post post={pagePost} postPage={false} />
-          <CreatePost isReply={true} />
+          {currentAuthUser && <CreatePost isReply={true} />}
           {pagePost.replies &&
             pagePost.replies.map((replyId) => {
               const foundPost = userPosts.find((post) => {

--- a/src/components/Profile/ProfileBanner.tsx
+++ b/src/components/Profile/ProfileBanner.tsx
@@ -13,57 +13,55 @@ import { Link } from 'react-router-dom'
 function ProfileBanner({ currentAuthUser, profileUserDoc }) {
   const { setModalIsOpen, setModalType } = useContext(ModalContext)
 
-  if (currentAuthUser) {
-    return (
-      <>
-        <Link to='/'>
-          <MdArrowBack className='absolute text-4xl bg-gray-900 rounded-full opacity-50 mt-3 ml-3' />
-        </Link>
-        <ProfileBannerImage />
-        <div className='w-full flex-col -mt-20'>
-          <div className='flex'>
-            <div className='w-3/4'>
-              <ProfilePicBubble addedClasses='w-32 h-32 ml-5' />
-            </div>
-            {currentAuthUser.uid === profileUserDoc.uid && (
-              <div className='w-2-5'>
-                <Button
-                  addedClasses='right-0 bg-slate-950 text-white border border-white px-5 h-10 mt-24 text-sm hover:bg-gray-900'
-                  onClick={() => {
-                    setModalIsOpen(true), setModalType('editProfile')
-                  }}
-                  type='button'
-                >
-                  <b>Edit Profile</b>
-                </Button>
-              </div>
-            )}
+  return (
+    <>
+      <Link to='/'>
+        <MdArrowBack className='absolute text-4xl bg-gray-900 rounded-full opacity-50 mt-3 ml-3 ' />
+      </Link>
+      <ProfileBannerImage />
+      <div className='w-full flex-col -mt-20 border-l border-r border-slate-700'>
+        <div className='flex'>
+          <div className='w-3/4'>
+            <ProfilePicBubble addedClasses='w-32 h-32 ml-5' />
           </div>
-          <div className='ml-5 mt-5 flex-col'>
-            <div>
-              <span className='text-xl'>
-                <b>{profileUserDoc.displayName}</b>
+          {currentAuthUser && currentAuthUser.uid === profileUserDoc.uid && (
+            <div className='w-2-5'>
+              <Button
+                addedClasses='right-0 bg-slate-950 text-white border border-white px-5 h-10 mt-24 text-sm hover:bg-gray-900'
+                onClick={() => {
+                  setModalIsOpen(true), setModalType('editProfile')
+                }}
+                type='button'
+              >
+                <b>Edit Profile</b>
+              </Button>
+            </div>
+          )}
+        </div>
+        <div className='ml-5 mt-5 flex-col'>
+          <div>
+            <span className='text-xl'>
+              <b>{profileUserDoc.displayName}</b>
+            </span>
+          </div>
+          <div>
+            <span className='text-md text-gray-500'>@{profileUserDoc.username}</span>
+          </div>
+          <div className='mt-5'>
+            <span className='text-lg'>{profileUserDoc.bio}</span>
+          </div>
+          {profileUserDoc.location && (
+            <div className='mt-5 flex-row'>
+              <span className='text-lg'>
+                <MdLocationOn className='inline mr-2 -mt-1' />
+                {profileUserDoc.location}
               </span>
             </div>
-            <div>
-              <span className='text-md text-gray-500'>@{profileUserDoc.username}</span>
-            </div>
-            <div className='mt-5'>
-              <span className='text-lg'>{profileUserDoc.bio}</span>
-            </div>
-            {profileUserDoc.location && (
-              <div className='mt-5 flex-row'>
-                <span className='text-lg'>
-                  <MdLocationOn className='inline mr-2 -mt-1' />
-                  {profileUserDoc.location}
-                </span>
-              </div>
-            )}
-          </div>
+          )}
         </div>
-      </>
-    )
-  }
+      </div>
+    </>
+  )
 }
 
 export default ProfileBanner

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -8,6 +8,8 @@ interface IModalContext {
   setModalType: Dispatch<SetStateAction<String>>
   replyModalPostId: String | null
   setReplyModalPostId: Dispatch<SetStateAction<IUserPost>>
+  loginWarningType: string
+  setLoginWarningType: Dispatch<SetStateAction<String>>
 }
 
 export const ModalContext = createContext<IModalContext>({
@@ -17,12 +19,15 @@ export const ModalContext = createContext<IModalContext>({
   setModalType: () => {},
   replyModalPostId: '',
   setReplyModalPostId: () => {},
+  loginWarningType: '',
+  setLoginWarningType: () => {},
 })
 
 function ModalProvider({ children }) {
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const [modalType, setModalType] = useState('')
   const [replyModalPostId, setReplyModalPostId] = useState(null)
+  const [loginWarningType, setLoginWarningType] = useState('')
 
   const value = {
     modalIsOpen,
@@ -31,6 +36,8 @@ function ModalProvider({ children }) {
     setModalType,
     replyModalPostId,
     setReplyModalPostId,
+    loginWarningType,
+    setLoginWarningType,
   }
 
   return <ModalContext.Provider value={value}>{children}</ModalContext.Provider>

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -50,7 +50,7 @@ function Profile() {
     return (
       <FeedContainer>
         <ProfileBanner currentAuthUser={currentAuthUser} profileUserDoc={profileUserDoc} />
-        <div className='text-center text-lg mt-5 pb-3 border-b border-slate-700'>
+        <div className='text-center text-lg pt-5 pb-3 border-b border-l border-r border-slate-700'>
           <span>
             <b>Posts</b>
           </span>


### PR DESCRIPTION
This PR will add hover effects to the clickable icons in the post interaction bar at the bottom of each individual post. Additionally, there are some smaller UI changes/fixes that this PR will address.

### Major Changes
- Add hover effects to comment, like, and repost icons in the post interaction bar at the bottom of each individual post.
    - This was done to make it easier for users to see what their cursor was hovering over and how they interact with the application. 
    - Each icon now has a background color change as well as a text color change when users hover over the icons. 
        - Comment button will change to cyan on hover
        - Like button will change to red on hover
            - When user is logged in and "likes" a post, the text and icon will remain red to more easily indicate that the post was "liked"
        - Repost button will change to green on hover
- Modals now show in center of the screen
     - I wasn't a fan of the previous modal location towards the top of he screen, so now all modals will appear at the middle of the screen regardless of view-height.
- When no user is logged in, clicking on the post interaction icons will open a unique modal indicating to the user that they are not logged in and prompts the user to either log in or create an account to interact with the post.

### Small Changes
- Feed container now has a minimum view height so that modal overlay encapsulates entire screen
- Borders were moved from feed container to each individual component so borders aren't running vertically along entire view height
- Change input border colors to darker color so that they don't stand out compared to the rest of the UI
- Fixed issue where back button was showing on top of Nav bar on profile page.
- Fixed an issue where profile wasn't being shown for users not logged in.