### PR TITLE
Delete posts feature and fixes

### DIFF
--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -3,7 +3,7 @@ import FeedContainer from './FeedContainer'
 import CreatePost from '../CreatePost/CreatePost'
 import LoadingSpinner from '../LoadingSpinner'
 
-import { UserPostsContext } from '../../contexts/UserPosts'
+import { IUserPost, UserPostsContext } from '../../contexts/UserPosts'
 import { FeedContext } from '../../contexts/FeedContext'
 import { MenuContext } from '../../contexts/MenuContext'
 import Post from '../Posts/Post'
@@ -22,8 +22,8 @@ function Feed() {
     <FeedContainer>
       <CreatePost isReply={false} />
       {userPosts ? (
-        userPosts.map((post) => {
-          return <Post key={post.postId} post={post} showInteractionBar={true} />
+        userPosts.map((post: IUserPost) => {
+          return <Post key={post.postId} post={post} />
         })
       ) : (
         <LoadingSpinner />

--- a/src/components/Modal/CreateReplyModal.tsx
+++ b/src/components/Modal/CreateReplyModal.tsx
@@ -43,7 +43,7 @@ const CreateReplyModal: FunctionComponent<ICreateReplyModalProps> = ({ post }) =
               <PostInfo post={post} />
             </PostInfoContainer>
             <div className='border-l border-slate-500 ml-9 -mt-3'>
-              <PostContent content={post.content} addedClasses='mt-3 ml-8' />
+              <PostContent content={post.content} addedClasses='mt-3 ml-8 mr-8' />
               <div className='ml-8 text-gray-500'>
                 <span>Replying to: </span>
                 <Link to={`/${post.username}`}>

--- a/src/components/Modal/DeletePostWarningModal.tsx
+++ b/src/components/Modal/DeletePostWarningModal.tsx
@@ -1,0 +1,57 @@
+import { useContext } from 'react'
+
+import { deleteUserPost } from '../../utils/firebase/firebase-config'
+
+import { ModalContext } from '../../contexts/ModalContext'
+import { PostMenuContext } from '../../contexts/PostMenuContext'
+
+import Button from '../Button'
+
+const DeletePostWarningModal = () => {
+  const { setModalIsOpen, setModalType } = useContext(ModalContext)
+  const { postMenuPost, setPostMenuPost } = useContext(PostMenuContext)
+
+  const deletePostHandler = () => {
+    deleteUserPost(postMenuPost)
+    setModalIsOpen(false)
+    setPostMenuPost(null)
+  }
+
+  const cancelDeleteHandler = () => {
+    setModalIsOpen(false)
+    setModalType(null)
+  }
+
+  return (
+    <div className='w-full'>
+      <div className='mt-10 mb-8 w-3/4 mx-auto'>
+        <span className='text-3xl font-bold'>Delete Post?</span>
+      </div>
+      <div className='w-3/4 mx-auto'>
+        <span className='text-lg text-slate-400'>
+          This post will be removed from existance. This can not be undone.
+        </span>
+      </div>
+      <div className='mt-10 w-1/2 mx-auto'>
+        <Button
+          type='button'
+          addedClasses='py-2 px-5 bg-red-500 text-white font-bold text-xl mr-20 w-full '
+          onClick={deletePostHandler}
+        >
+          Delete
+        </Button>
+      </div>
+      <div className='mt-4 w-1/2 mx-auto'>
+        <Button
+          type='button'
+          addedClasses='py-2 px-5 bg-slate-950 text-white border border-white font-bold text-xl w-full mb-10 hover:bg-slate-900'
+          onClick={cancelDeleteHandler}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default DeletePostWarningModal

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,35 +1,49 @@
 import { useContext } from 'react'
 import EditProfileForm from '../Forms/EditProfileForm'
 
-import { ModalContext } from '../../contexts/ModalContext'
-import CreateReplyModal from './CreateReplyModal'
 import { IUserPost, UserPostsContext } from '../../contexts/UserPosts'
+import { ModalContext } from '../../contexts/ModalContext'
+import { PostMenuContext } from '../../contexts/PostMenuContext'
+
+import CreateReplyModal from './CreateReplyModal'
 import LoginWarningModal from './LoginWarningModal'
+import DeletePostWarningModal from './DeletePostWarningModal'
 
 function Modal({ children }) {
   const { modalIsOpen, modalType, replyModalPostId, setModalIsOpen } = useContext(ModalContext)
   const { userPosts } = useContext(UserPostsContext)
+  const { postMenuIsOpen } = useContext(PostMenuContext)
 
   const replyModalPost: IUserPost =
     userPosts && userPosts.find((post) => post.postId == replyModalPostId)
 
+  const modalCloseHandler = (e) => {
+    e.preventDefault()
+    setModalIsOpen(false)
+  }
+
   return (
-    <div>
+    <div className={`${postMenuIsOpen && 'pointer-events-none'}`}>
       {modalIsOpen && (
-        <div className={`flex fixed mx-auto w-full z-50 h-screen items-center`}>
-          <div className='bg-slate-950 w-3/5 lg:w-1/2 max-w-xl z-10 mx-auto rounded-xl'>
+        <div
+          className={`flex fixed mx-auto w-full h-screen items-center z-10`}
+          onClick={modalCloseHandler}
+        >
+          <div
+            className='bg-slate-950 w-full lg:w-1/2 max-w-xl mx-auto rounded-xl'
+            onClick={(e) => e.stopPropagation()}
+          >
             {modalType == 'editProfile' && <EditProfileForm />}
             {modalType == 'createPostReply' && (
               <div className='py-10'>{userPosts && <CreateReplyModal post={replyModalPost} />}</div>
             )}
             {modalType == 'loginWarning' && <LoginWarningModal />}
+            {modalType == 'deletePostWarning' && <DeletePostWarningModal />}
           </div>
         </div>
       )}
 
-      <div className={`${modalIsOpen && 'opacity-40 bg-gray-500 '}w-full h-full z-10`}>
-        {children}
-      </div>
+      <div className={`${modalIsOpen && 'opacity-40 bg-gray-500 '}w-full h-full`}>{children}</div>
     </div>
   )
 }

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -3,7 +3,7 @@ import { useContext, useState, useEffect } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 
 import { FeedContext } from '../../contexts/FeedContext'
-import { UserPostsContext } from '../../contexts/UserPosts'
+import { IUserPost, UserPostsContext } from '../../contexts/UserPosts'
 
 import PostContainer from './PostContainer'
 import PostInfoContainer from './PostInfoContainer'
@@ -11,8 +11,14 @@ import PostInfo from './PostInfo'
 import ProfilePicBubble from '../Profile/ProfilePicBubble'
 import PostContent from './PostContent'
 import PostInteractionBar from './PostInteractionBar'
+import PostMenu from './PostMenu'
 
-function Post({ post, postPage }) {
+interface PostProps {
+  post: IUserPost
+  postPage?: boolean
+}
+
+function Post({ post, postPage }: PostProps) {
   const [originalPost, setOriginalPost] = useState(null)
   const { isLoading } = useContext(FeedContext)
   const { userPosts } = useContext(UserPostsContext)
@@ -42,59 +48,67 @@ function Post({ post, postPage }) {
     navigate(`/${originalPost.username}/status/${originalPost.postId}`)
   }
 
+  console.log(post)
+
   if (post.replyTo && !postPage && originalPost) {
     return (
-      <Link to={`/${post.username}/status/${post.postId}`}>
-        <div className='border-b border-l border-r border-slate-700 pr-16'>
-          <PostContainer isLoading={isLoading}>
-            <PostInfoContainer>
-              <ProfilePicBubble
-                onClick={navigateToProfileOnClick}
-                addedClasses='mx-5 h-8 w-8 mt-5'
-              />
-              <PostInfo post={post} />
-            </PostInfoContainer>
-            <PostContent content={post.content} addedClasses='ml-16' />
-          </PostContainer>
-          <div
-            onClick={navigateToPostOnClick}
-            className='ml-10 mr-5 my-5 border border-slate-700 rounded-lg'
-          >
-            <PostContainer isLoading={isLoading} addedClasses=''>
+      <Link className={''} to={`/${post.username}/status/${post.postId}`}>
+        <div className='border-b border-l border-r border-slate-700 '>
+          <div className='w-full pr-16 relative'>
+            <PostMenu post={post} />
+            <PostContainer isLoading={isLoading}>
               <PostInfoContainer>
                 <ProfilePicBubble
                   onClick={navigateToProfileOnClick}
-                  profilePic={originalPost.profilePic}
                   addedClasses='mx-5 h-8 w-8 mt-5'
                 />
-                <PostInfo post={originalPost} />
+                <PostInfo post={post} />
               </PostInfoContainer>
-              <PostContent content={originalPost.content} addedClasses='ml-16 mr-8' />
+              <PostContent content={post.content} addedClasses='ml-16' />
             </PostContainer>
+            <div
+              onClick={navigateToPostOnClick}
+              className='ml-10 mr-0 lg:mr-5 my-5 border border-slate-700 rounded-lg'
+            >
+              <PostContainer isLoading={isLoading} addedClasses=''>
+                <PostInfoContainer>
+                  <ProfilePicBubble
+                    onClick={navigateToProfileOnClick}
+                    profilePic={originalPost.profilePic}
+                    addedClasses='mx-5 h-8 w-8 mt-5'
+                  />
+                  <PostInfo post={originalPost} />
+                </PostInfoContainer>
+                <PostContent content={originalPost.content} addedClasses='ml-16 mr-8' />
+              </PostContainer>
+            </div>
+            <PostInteractionBar post={post} />
           </div>
-          <PostInteractionBar post={post} />
         </div>
       </Link>
     )
   }
 
   return (
-    <Link to={`/${post.username}/status/${post.postId}`}>
-      <PostContainer
-        isLoading={isLoading}
-        addedClasses='border-b border-l border-r border-slate-700 pr-16'
-      >
-        <PostInfoContainer>
-          <ProfilePicBubble
-            onClick={navigateToProfileOnClick}
-            profilePic={post.profilePic}
-            addedClasses='mx-5 h-8 w-8 mt-5'
-          />
-          <PostInfo post={post} />
-        </PostInfoContainer>
-        <PostContent content={post.content} addedClasses='ml-16' />
-        <PostInteractionBar post={post} />
-      </PostContainer>
+    <Link className={''} to={`/${post.username}/status/${post.postId}`}>
+      <div className='w-full relative'>
+        <PostMenu post={post} />
+        <PostContainer
+          isLoading={isLoading}
+          addedClasses='border-b border-l border-r border-slate-700 pr-16'
+        >
+          <PostInfoContainer>
+            <ProfilePicBubble
+              onClick={navigateToProfileOnClick}
+              profilePic={post.profilePic}
+              addedClasses='mx-5 h-8 w-8 mt-5'
+            />
+            <PostInfo post={post} />
+          </PostInfoContainer>
+          <PostContent content={post.content} addedClasses='ml-16' />
+          <PostInteractionBar post={post} />
+        </PostContainer>
+      </div>
     </Link>
   )
 }

--- a/src/components/Posts/PostMenu.tsx
+++ b/src/components/Posts/PostMenu.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState, useContext } from 'react'
+
+import { MdMoreHoriz } from 'react-icons/md'
+import { FaRegTrashAlt } from 'react-icons/fa'
+import { MdOutlineShare } from 'react-icons/md'
+
+import { IUserPost } from '../../contexts/UserPosts'
+
+import { UserContext } from '../../contexts/User'
+import { PostMenuContext } from '../../contexts/PostMenuContext'
+import { ModalContext } from '../../contexts/ModalContext'
+
+interface PostMenuProps {
+  post: IUserPost
+}
+
+const PostMenu = ({ post }: PostMenuProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const { setPostMenuIsOpen, setPostMenuPost, postMenuPost } = useContext(PostMenuContext)
+  const { setModalType, setModalIsOpen } = useContext(ModalContext)
+  const { currentAuthUser } = useContext(UserContext)
+
+  const menuIconClickHandler = (e) => {
+    e.preventDefault()
+
+    setIsOpen(true)
+    setPostMenuIsOpen(true)
+    setPostMenuPost(post)
+  }
+  const menuClickHandler = (e) => {
+    e.preventDefault()
+  }
+
+  const menuCloseHandler = () => {
+    if (isOpen) {
+      setIsOpen(false)
+      setPostMenuIsOpen(false)
+    }
+  }
+
+  const deleteButtonHandler = (e) => {
+    e.preventDefault()
+    setModalType('deletePostWarning')
+    setModalIsOpen(true)
+  }
+
+  useEffect(() => {
+    document.addEventListener('mouseup', menuCloseHandler)
+  })
+
+  return (
+    <div className='pointer-events-auto' onClick={menuClickHandler}>
+      <MdMoreHoriz
+        className='absolute right-5 mt-4 text-3xl text-slate-500 hover:bg-slate-800 rounded-full p-0.5 hover:cursor-pointer'
+        onClick={menuIconClickHandler}
+      />
+      <div
+        className={`
+        absolute w-2/5 right-0 mt-2 mr-2 border border-slate-700 rounded-lg bg-slate-950 
+        outline outline-1 outline-cyan-500  ${!isOpen && 'hidden '}`}
+      >
+        {post.uid === currentAuthUser.uid && (
+          <div
+            className='pl-6 text-red-500 py-2 hover:bg-slate-900 z-20'
+            onClick={deleteButtonHandler}
+          >
+            <FaRegTrashAlt className='inline mb-1 text-md mr-3' />
+            <span className='font-bold'>Delete</span>
+          </div>
+        )}
+        <div className='pl-6 text-slate-300 py-2 hover:bg-slate-900 '>
+          <MdOutlineShare className='inline mb-1 text-md mr-3' />
+          <span className='font-bold'>Share Post</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PostMenu

--- a/src/contexts/PostMenuContext.tsx
+++ b/src/contexts/PostMenuContext.tsx
@@ -1,0 +1,32 @@
+import { useState, createContext, Dispatch, SetStateAction } from 'react'
+import { IUserPost } from './UserPosts'
+
+interface IPostMenuContext {
+  postMenuIsOpen: Boolean
+  setPostMenuIsOpen: Dispatch<SetStateAction<Boolean>>
+  postMenuPost: IUserPost | null
+  setPostMenuPost: Dispatch<SetStateAction<IUserPost>>
+}
+
+export const PostMenuContext = createContext<IPostMenuContext>({
+  postMenuIsOpen: false,
+  setPostMenuIsOpen: () => {},
+  postMenuPost: null,
+  setPostMenuPost: () => {},
+})
+
+function PostMenuProvider({ children }) {
+  const [postMenuIsOpen, setPostMenuIsOpen] = useState(false)
+  const [postMenuPost, setPostMenuPost] = useState(null)
+
+  const value = {
+    postMenuIsOpen,
+    setPostMenuIsOpen,
+    postMenuPost,
+    setPostMenuPost,
+  }
+
+  return <PostMenuContext.Provider value={value}>{children}</PostMenuContext.Provider>
+}
+
+export default PostMenuProvider

--- a/src/contexts/UserPosts.tsx
+++ b/src/contexts/UserPosts.tsx
@@ -4,15 +4,15 @@ import { createUserPost } from '../utils/firebase/firebase-config'
 import firebase from 'firebase/compat/app'
 
 export interface IUserPost {
-  content: String
-  displayName: String
+  content: string
+  displayName: string
   likes: number
-  postId: String
+  postId: string
   replies: Array<IUserPost> | null
-  replyTo: String | false
+  replyTo: string | false
   timestamp: Date
-  uid: String
-  username: String
+  uid: string
+  username: string
 }
 
 interface IUserPostsContext {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import UserPostsProvider from './contexts/UserPosts.tsx'
 import FeedProvider from './contexts/FeedContext.tsx'
 import MenuProvider from './contexts/MenuContext.tsx'
 import ModalProvider from './contexts/ModalContext.tsx'
+import PostMenuProvider from './contexts/PostMenuContext.tsx'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
@@ -17,9 +18,11 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
         <MenuProvider>
           <FeedProvider>
             <UserPostsProvider>
-              <ModalProvider>
-                <App />
-              </ModalProvider>
+              <PostMenuProvider>
+                <ModalProvider>
+                  <App />
+                </ModalProvider>
+              </PostMenuProvider>
             </UserPostsProvider>
           </FeedProvider>
         </MenuProvider>


### PR DESCRIPTION
This PR will add feature which allows users to delete their own posts and replies to other posts. There are additionally some other small changes that will be outlined below.

### Major Changes
- Add menu icon to each individual post
    - Will display button to allow users to share the post
    - If it is the user's own post, it will display an option to delete the post
- Post deletion
    - Users are now able to delete posts and replies that they have created
    - Application checks that the currently authenticated user matches the user that created the post
    - Users are displayed a warning when clicking to delete a post to help ensure no post is deleted accidentally
### Smaller Changes
- Modal click-off to close
   - Users can now click off of the modal instead of clicking the X button to close all modals
- Additional type checking was added to assist in development and error prevention
- Margin added to post content in reply creation modal for better viewing on  smaller devices.
- Various changes to responsiveness in different viewport sizes for better user experience on smaller devices.