### PR TITLE
Likes rework

### DIFF
--- a/src/components/Modal/DeletePostWarningModal.tsx
+++ b/src/components/Modal/DeletePostWarningModal.tsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react'
+import { useParams, useNavigate } from 'react-router'
 
 import { deleteUserPost } from '../../utils/firebase/firebase-config'
 
@@ -11,8 +12,12 @@ const DeletePostWarningModal = () => {
   const { setModalIsOpen, setModalType } = useContext(ModalContext)
   const { postMenuPost, setPostMenuPost } = useContext(PostMenuContext)
 
+  const params = useParams()
+  const navigate = useNavigate()
+
   const deletePostHandler = () => {
     deleteUserPost(postMenuPost)
+    params.postId && navigate(-1)
     setModalIsOpen(false)
     setPostMenuPost(null)
   }

--- a/src/components/Posts/PostInteractionBar.tsx
+++ b/src/components/Posts/PostInteractionBar.tsx
@@ -60,12 +60,12 @@ const PostInteractionBar = ({ post }) => {
             {currentUserDoc.likedPosts.find((likedPost) => likedPost == post.postId) ? (
               <div className='inline text-red-400'>
                 <MdFavorite className='text-xl mx-auto inline' />
-                <span className='ml-2'>{post.likes}</span>
+                <span className='ml-2'>{post.likes.length}</span>
               </div>
             ) : (
               <div className='inline'>
                 <MdFavoriteBorder className='text-xl mx-auto inline' />
-                <span className='ml-2'>{post.likes}</span>
+                <span className='ml-2'>{post.likes.length}</span>
               </div>
             )}
           </div>


### PR DESCRIPTION
This PR will change how likes are stored on userPosts. Previously it was by ammount, but now will be stored as the user's uid so that likes are tied to users.

Also changed postPage to navigate back after post is deleted to fix infinite loading spinner issue.