### PR TITLE
Profile banner cropper/uploader

### DIFF
--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -21,7 +21,6 @@ function Feed() {
       Math.ceil(window.innerHeight + window.scrollY) >= document.documentElement.scrollHeight
 
     if (bottom) {
-      console.log('bottom')
       setPostAmount(postAmount + 10)
     }
   }

--- a/src/components/Forms/EditProfileForm.tsx
+++ b/src/components/Forms/EditProfileForm.tsx
@@ -11,12 +11,13 @@ import { CropperContext } from '../../contexts/CropperContext.js'
 import { MODAL_TYPES } from '../../contexts/ModalContext'
 const { photoCrop } = MODAL_TYPES
 
+import { PHOTO_TYPES } from '../../contexts/CropperContext.js'
+const { profilePic, bannerPic } = PHOTO_TYPES
+
 import ProfilePicBubble from '../Profile/ProfilePicBubble'
 import ProfileBannerImage from '../Profile/ProfileBannerImage'
 import Button from '../Button'
 import FormInput from './FormInput'
-import { User } from 'firebase/auth'
-import { DocumentData, DocumentSnapshot } from 'firebase/firestore'
 
 export interface IEditProfileFormFields {
   displayName: string
@@ -28,7 +29,7 @@ export interface IEditProfileFormFields {
 const EditProfileForm = () => {
   const { currentAuthUser, setCurrentUserDoc, currentUserDoc } = useContext(UserContext)
   const { modalIsOpen, setModalIsOpen, setModalType } = useContext(ModalContext)
-  const { setPhotoToBeCropped } = useContext(CropperContext)
+  const { setPhotoToBeCropped, setPhotoType } = useContext(CropperContext)
 
   const defaultFormFields: IEditProfileFormFields = {
     displayName: '',
@@ -87,9 +88,14 @@ const EditProfileForm = () => {
   }
 
   const inputProfilePic = useRef(null)
+  const inputBannerPic = useRef(null)
 
   const inputProfilePicClickHandler = () => {
     inputProfilePic.current.click()
+  }
+
+  const inputBannerPicClickHandler = () => {
+    inputBannerPic.current.click()
   }
 
   //Opens photo crop modal when user changes file input w/ current file
@@ -97,7 +103,21 @@ const EditProfileForm = () => {
     if (e.target.files && e.target.files.length > 0) {
       const reader = new FileReader()
       reader.readAsDataURL(e.target.files[0])
-      reader.addEventListener('load', () => setPhotoToBeCropped(reader.result.toString()))
+      reader.addEventListener('load', () => {
+        setPhotoToBeCropped(reader.result.toString())
+        setPhotoType(profilePic)
+      })
+      setModalType(photoCrop)
+    }
+  }
+  const inputBannerPicChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      const reader = new FileReader()
+      reader.readAsDataURL(e.target.files[0])
+      reader.addEventListener('load', () => {
+        setPhotoType(bannerPic)
+        setPhotoToBeCropped(reader.result.toString())
+      })
       setModalType(photoCrop)
     }
   }
@@ -124,9 +144,10 @@ const EditProfileForm = () => {
           </div>
         </div>
         <div className='relative '>
-          <ProfileBannerImage />
+          <ProfileBannerImage user={currentUserDoc} />
           <MdCameraAlt
             className={`absolute bg-opacity-60 bg-gray-700 rounded-full text-6xl -mr-6 -mt-6 p-3 right-1/2 top-1/2 text-cyan-300 z-20 hover:cursor-pointer hover:bg-gray-600 hover:bg-opacity-60`}
+            onClick={inputBannerPicClickHandler}
           />
         </div>
         <div className='z-10 relative'>
@@ -146,6 +167,14 @@ const EditProfileForm = () => {
               accept='.png, .jpg, .jpeg'
               className='hidden'
               onChange={inputProfilePicChangeHandler}
+            />
+            <input
+              type='file'
+              id='bannerPic'
+              ref={inputBannerPic}
+              accept='.png, .jpg, .jpeg'
+              className='hidden'
+              onChange={inputBannerPicChangeHandler}
             />
           </div>
         </div>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -52,7 +52,7 @@ function Menu() {
       return (
         <div className='absolute right-5'>
           <ProfilePicBubble
-            addedClasses='w-10 h-10 cursor-pointer mt-5'
+            addedClasses='w-14 h-14 cursor-pointer mt-3'
             onClick={menuClickHandler}
             profilePic={currentUserDoc.profilePic}
           />

--- a/src/components/Menu/MenuHeader.tsx
+++ b/src/components/Menu/MenuHeader.tsx
@@ -12,10 +12,10 @@ function MenuHeader({ onClick }) {
     <Link onClick={onClick} to={`/${currentUserDoc.username}`}>
       <div className='flex ml-5 pl-0 mt-4'>
         <ProfilePicBubble
-          addedClasses='w-10 h-10'
+          addedClasses='w-14 h-14'
           profilePic={currentUserDoc.profilePic.toString()}
         />
-        <span className='w-3/4 ml-3 text-xl'>
+        <span className='w-3/4 ml-5 mt-3 text-xl'>
           <b>{currentUserDoc.displayName}</b>
         </span>
       </div>

--- a/src/components/Modal/PhotoCropModal.tsx
+++ b/src/components/Modal/PhotoCropModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useContext } from 'react'
+import { useState, useCallback, useContext, useEffect } from 'react'
 import Cropper from 'react-easy-crop'
 
 import { generateCroppedImage } from '../../utils/cropImage'
@@ -17,8 +17,9 @@ const PhotoCropModal = () => {
   const [crop, setCrop] = useState({ x: 0, y: 0 })
   const [zoom, setZoom] = useState(1)
   const [finishedCrop, setFinishedCrop] = useState(null)
+  const [aspect, setAspect] = useState(null)
 
-  const { photoToBeCropped, setPhotoToBeCropped } = useContext(CropperContext)
+  const { photoToBeCropped, setPhotoToBeCropped, photoType } = useContext(CropperContext)
   const { setModalType } = useContext(ModalContext)
   const { currentUserDoc } = useContext(UserContext)
 
@@ -37,11 +38,23 @@ const PhotoCropModal = () => {
 
   const applyButtonClickHandler = () => {
     //Takes cropped image, saves to cloud, stores to userdoc
-    generateCroppedImage(photoToBeCropped, finishedCrop, currentUserDoc)
+    generateCroppedImage(photoToBeCropped, finishedCrop, currentUserDoc, photoType)
 
     setPhotoToBeCropped('')
     setModalType(editProfile)
   }
+
+  //Sets aspect ratio based on photoType
+  useEffect(() => {
+    switch (photoType) {
+      case 'profilePic':
+        setAspect(3 / 3)
+        break
+      case 'bannerPic':
+        setAspect(3 / 1)
+        break
+    }
+  }, [photoType])
 
   return (
     <>
@@ -72,7 +85,7 @@ const PhotoCropModal = () => {
           image={photoToBeCropped}
           crop={crop}
           zoom={zoom}
-          aspect={3 / 3}
+          aspect={aspect}
           onCropChange={setCrop}
           onCropComplete={onCropComplete}
           onZoomChange={setZoom}

--- a/src/components/Profile/ProfileBanner.tsx
+++ b/src/components/Profile/ProfileBanner.tsx
@@ -22,7 +22,7 @@ function ProfileBanner({ currentAuthUser, profileUserDoc }) {
       <Link to='/'>
         <MdArrowBack className='absolute text-4xl bg-gray-900 rounded-full opacity-50 mt-3 ml-3 ' />
       </Link>
-      <ProfileBannerImage />
+      <ProfileBannerImage user={profileUserDoc} />
       <div className='w-full flex-col -mt-20 border-l border-r border-slate-700'>
         <div className='flex'>
           <div className='w-3/4'>

--- a/src/components/Profile/ProfileBannerImage.tsx
+++ b/src/components/Profile/ProfileBannerImage.tsx
@@ -1,7 +1,11 @@
-function ProfileBannerImage() {
+function ProfileBannerImage({ user }) {
   return (
     <div>
-      <img src='https://www.aashe.org/wp-content/uploads/2018/02/Placeholder-Banner.png' />
+      {user.bannerPic ? (
+        <img src={user.bannerPic} />
+      ) : (
+        <img src='https://firebasestorage.googleapis.com/v0/b/mnufc-6f9e3.appspot.com/o/United%20Banner%20Image.jpg?alt=media&token=580815fc-050c-4fd4-b21a-a176debb7d81' />
+      )}
     </div>
   )
 }

--- a/src/contexts/CropperContext.tsx
+++ b/src/contexts/CropperContext.tsx
@@ -3,19 +3,31 @@ import { Dispatch, SetStateAction, createContext, useState } from 'react'
 interface ICropperContext {
   photoToBeCropped: string
   setPhotoToBeCropped: Dispatch<SetStateAction<string>>
+  photoType: string
+  setPhotoType: Dispatch<SetStateAction<string>>
 }
 
 export const CropperContext = createContext<ICropperContext>({
   photoToBeCropped: null,
   setPhotoToBeCropped: () => {},
+  photoType: null,
+  setPhotoType: () => {},
 })
+
+export const PHOTO_TYPES = {
+  profilePic: 'profilePic',
+  bannerPic: 'bannerPic',
+}
 
 function CropperProvider({ children }) {
   const [photoToBeCropped, setPhotoToBeCropped] = useState(null)
+  const [photoType, setPhotoType] = useState(null)
 
   const value = {
     photoToBeCropped,
     setPhotoToBeCropped,
+    photoType,
+    setPhotoType,
   }
 
   return <CropperContext.Provider value={value}>{children}</CropperContext.Provider>

--- a/src/utils/cropImage.ts
+++ b/src/utils/cropImage.ts
@@ -5,7 +5,10 @@
  * @param {number} rotation - optional rotation parameter
  */
 
-import { uploadProfilePicture } from './firebase/firebase-config'
+import { uploadBannerPicture, uploadProfilePicture } from './firebase/firebase-config'
+
+import { PHOTO_TYPES } from '../contexts/CropperContext'
+const { profilePic, bannerPic } = PHOTO_TYPES
 
 const createImage = (url) =>
   new Promise((resolve, reject) => {
@@ -59,7 +62,7 @@ export default async function getCroppedImg(imageSrc, pixelCrop, rotation = 0) {
   return canvas
 }
 
-export const generateCroppedImage = async (imageSrc, crop, currentUserDoc) => {
+export const generateCroppedImage = async (imageSrc, crop, currentUserDoc, photoType) => {
   if (!crop || !imageSrc) {
     return
   }
@@ -68,7 +71,14 @@ export const generateCroppedImage = async (imageSrc, crop, currentUserDoc) => {
 
   canvas.toBlob(
     (blob) => {
-      uploadProfilePicture(blob, currentUserDoc)
+      switch (photoType) {
+        case profilePic:
+          uploadProfilePicture(blob, currentUserDoc)
+          break
+        case bannerPic:
+          uploadBannerPicture(blob, currentUserDoc)
+          break
+      }
     },
     'image/jpeg',
     0.66

--- a/src/utils/firebase/firebase-config.ts
+++ b/src/utils/firebase/firebase-config.ts
@@ -317,6 +317,14 @@ export const uploadProfilePicture = (blob: Blob, currentUserDoc: IUserDoc) => {
       updateDoc(doc(db, 'users', currentUserDoc.uid.toString()), { profilePic: res })
     })
   })
+}
 
-  console.log(pfpRef.fullPath)
+export const uploadBannerPicture = (blob: Blob, currentUserDoc: IUserDoc) => {
+  const bannerRef = ref(storage, currentUserDoc.username + `/bannerPics/bnr-` + Date.now())
+
+  uploadBytes(bannerRef, blob).then(() => {
+    getDownloadURL(bannerRef).then((res) => {
+      updateDoc(doc(db, 'users', currentUserDoc.uid.toString()), { bannerPic: res })
+    })
+  })
 }


### PR DESCRIPTION
This PR will introduce functionality to banner upload button in edit profile form

### Major Changes

**Banner Pictures**
- Users can now upload banner photos to be displayed at the top of their profile page
	- Photos are in 3/1 aspect ratio
	- When users click on the camera button overlayed on the banner image in the edit profile form, they can upload a photo.
		- When user inputs a file, they will be taken to photo cropper to crop their image to ensure it is the proper aspect ratio prior to upload to storage.
- Banner images at top of user profile is now fetched from the user's document if they have uploaded one
- If the user has not uploaded a banner image, the default "United" banner image will be displayed